### PR TITLE
CPUs per GPU ratio; more cute printing

### DIFF
--- a/bash_user_summary.sh
+++ b/bash_user_summary.sh
@@ -1,47 +1,41 @@
 #!/bin/bash
-
 #This is a script to find the resources in Puhti cluster/CSC
 #Developed in Tampere University, Computer-Vision Group.
-
-
-
 ####################################################################################
 #sinfo -N -p gpu -o %a -O "nodehost,available,cpus,cpusload,cpusstate" --noheader
 #sinfo -N -p gpu -o %a -O "nodehost,available,cpusstate" --noheader
-
 # find the nodes with least CPU usage: in gpu partition: 1 in the cut command stands for allocated cpus in a node, 2 will stand for idle, 3 for other and 4 for total which is 40.
 #echo
 #echo 'Recommended node with least amount of CPU usages |N|S|Coresinuse|'
 #CPU=`sinfo -N -p gpu -o %a -O "nodehost,available,cpusstate" --noheader | cut -d "/" -f 1 | sort -nr -k3 | tail -10`
-
 #echo "$CPU"
-
 #Total number of gpus in use
 #####################################################################################
-
 echo
 echo '*** WELCOME TO DYNAMIC PUHTI-RESOURCE FINDER SYSTEM ***'
 echo
-
 #####################################################################################
- echo '|USER|CPUs_in_use|GPUs_in_use|'
- echo
 
+# HEADER 
+printf '%10s %4s %3s %7s' "USER" "CPU" "GPU" "CPU/GPU"
+echo
 
 unique_users=`squeue -h -p gpu -o "%u" | sort | uniq`
 
 for value in $unique_users
- do
-     #if ['$value' != 'USER'];
-     #then
-	 gpu_in_use=`sacct -n -X --state running --user  $value --format=jobid,elapsed,ncpus,ntasks,state,AllocGRES | awk '{print $5}' | awk -F '[ :]' '{print $2}' | awk '{s+=$1} END {print s}'`
- 	 cpu_in_use=`sacct -n -X --state running --user  $value --format=jobid,elapsed,ncpus,ntasks,state,AllocGRES | awk '{print $3}' | awk '{s+=$1} END {print s}'`
+	do
+		gpu_in_use=`sacct -n -X --state running --user  $value --format=jobid,elapsed,ncpus,ntasks,state,AllocGRES | awk '{print $5}' | awk -F '[ :]' '{print $2}' | awk '{s+=$1} END {print s}'`
+		cpu_in_use=`sacct -n -X --state running --user  $value --format=jobid,elapsed,ncpus,ntasks,state,AllocGRES | awk '{print $3}' | awk '{s+=$1} END {print s}'`
 
-	 while IFS= read -r -u2 u && read -r -u3 a && read -r -u4 b; do
-	     printf '%s%10s%10s\n' "$u" "$a" "$b"
-	 done 2<<<"$value" 3<<<"$cpu_in_use" 4<<<"$gpu_in_use"
+		# if $gpu_in_use is empty, then a user waits in the queue CPU/GPU is -1
+		if [ -z "$gpu_in_use" ]
+		then
+			cpu_per_gpu=`echo -1`
+		else
+			cpu_per_gpu=`echo $cpu_in_use / $gpu_in_use | bc -l`
+		fi
 
-	 echo
-	 #echo $cpu_in_use
-     #fi
- done
+		while IFS= read -r -u2 u && read -r -u3 a && read -r -u4 b && read -r -u5 c; do
+			printf '%10s %4d %3s %7.1f\n' "$u" "$a" "$b" "$c"
+		done 2<<<"$value" 3<<<"$cpu_in_use" 4<<<"$gpu_in_use" 5<<<"$cpu_per_gpu"
+	done


### PR DESCRIPTION
Example printing. 

_Note_: when `CPU` is 0 and `GPU` is empty, it means a user is in the queue, in this case, `-1.0` is returned in `CPU/GPU` column. I wanted to make it be `WAIT` or some other more meaningful string but `printf` is quite strict about the formatting: it is either a float or string. Therefore, it will be empty if `GPU` is empty. Now I think that it might be more beneficial but these are the details. Feel free to change this part of the commit.

```

*** WELCOME TO DYNAMIC PUHTI-RESOURCE FINDER SYSTEM ***

      USER  CPU GPU CPU/GPU
 XXXXXXXXX   10   8     1.2
 XXXXXXXXX    4   4     1.0
 XXXXXXXXX    1   1     1.0
 XXXXXXXXX    2   2     1.0
 XXXXXXXXX    2   4     0.5
 XXXXXXXXX    5  10     0.5
 XXXXXXXXX   40   5     8.0
 XXXXXXXXX    2   8     0.2
 XXXXXXXXX    1  32     0.0
 XXXXXXXXX   24   6     4.0
 XXXXXXXXX   20   2    10.0
 XXXXXXXXX    1   1     1.0
 XXXXXXXXX   24   3     8.0
 XXXXXXXXX   32   2    16.0
 XXXXXXXXX    8   2     4.0
 XXXXXXXXX    0        -1.0
 XXXXXXXXX    5   5     1.0
 XXXXXXXXX  325  65     5.0
 XXXXXXXXX    3   3     1.0
 XXXXXXXXX    4   4     1.0
 XXXXXXXXX   50  20     2.5
 XXXXXXXXX   38   4     9.5
 XXXXXXXXX   25   4     6.2
 XXXXXXXXX    1   1     1.0
 XXXXXXXXX    3   3     1.0
 XXXXXXXXX    7  21     0.3
 XXXXXXXXX    5   1     5.0
 XXXXXXXXX    1   1     1.0
 XXXXXXXXX  120  20     6.0
 XXXXXXXXX    1   2     0.5
 XXXXXXXXX    4   1     4.0
 XXXXXXXXX    3   4     0.8
 XXXXXXXXX   36   6     6.0
 XXXXXXXXX    2   2     1.0
 XXXXXXXXX    5  14     0.4
 XXXXXXXXX   80   4    20.0
 XXXXXXXXX   20   5     4.0
 XXXXXXXXX    3   3     1.0
 XXXXXXXXX    3   3     1.0
 XXXXXXXXX    4   2     2.0
 XXXXXXXXX    4   4     1.0
```